### PR TITLE
Retour en arrière vers le formulaire de simulation sans besoin de rec…

### DIFF
--- a/impact/public/tests/test_simulation.py
+++ b/impact/public/tests/test_simulation.py
@@ -82,7 +82,7 @@ def test_premiere_simulation_sur_entreprise_inexistante_en_bdd(
             return_value=status_est_soumis,
         )
 
-    response = client.post("/simulation", data=data)
+    response = client.post("/simulation", data=data, follow=True)
 
     # l'entreprise a été créée avec les caractéristiques de simulation
     entreprise = Entreprise.objects.get(siren=siren)
@@ -153,8 +153,9 @@ def test_premiere_simulation_sur_entreprise_inexistante_en_bdd(
     simulation_form = context["simulation_form"]
     assert simulation_form["siren"].value() == siren
     assert simulation_form["denomination"].value() == denomination
-    assert simulation_form["categorie_juridique_sirene"].value() == str(
-        categorie_juridique_sirene
+    assert (
+        simulation_form["categorie_juridique_sirene"].value()
+        == categorie_juridique_sirene
     )
     assert simulation_form["effectif"].value() == effectif
     assert simulation_form["tranche_chiffre_affaires"].value() == ca
@@ -199,7 +200,7 @@ def test_simulation_par_un_utilisateur_authentifie_sur_une_nouvelle_entreprise(
             return_value=status_est_soumis,
         )
 
-    response = client.post("/simulation", data=data)
+    response = client.post("/simulation", data=data, follow=True)
 
     content = response.content.decode("utf-8")
     reglementations = response.context["reglementations"]
@@ -260,7 +261,7 @@ def test_lors_d_une_simulation_les_donnees_d_une_entreprise_avec_des_caracterist
         "appartient_groupe": False,
     }
 
-    response = client.post("/simulation", data=data)
+    response = client.post("/simulation", data=data, follow=True)
 
     entreprise.refresh_from_db()
     assert entreprise.date_cloture_exercice == date_cloture_dernier_exercice
@@ -357,7 +358,7 @@ def test_lors_d_une_simulation_les_donnees_d_une_entreprise_avec_utilisateur_ne_
         "tranche_bilan_consolide": bilan,
     }
 
-    response = client.post("/simulation", data=data)
+    response = client.post("/simulation", data=data, follow=True)
 
     entreprise.refresh_from_db()
     assert entreprise.date_cloture_exercice is None
@@ -433,7 +434,7 @@ def test_lors_d_une_simulation_les_donnees_d_une_entreprise_sans_caracteristique
         "tranche_bilan_consolide": bilan,
     }
 
-    response = client.post("/simulation", data=data)
+    response = client.post("/simulation", data=data, follow=True)
 
     entreprise.refresh_from_db()
     assert entreprise.date_cloture_exercice is None

--- a/impact/public/views.py
+++ b/impact/public/views.py
@@ -102,12 +102,41 @@ def simulation(request):
     if request.POST:
         if simulation_form.is_valid():
             reglementations = calcule_simulation(simulation_form, request.user)
-            request.session["siren"] = simulation_form.cleaned_data["siren"]
+            request.session["simulation"] = {
+                "siren": simulation_form.cleaned_data["siren"],
+                "denomination": simulation_form.cleaned_data["denomination"],
+                "categorie_juridique_sirene": simulation_form.cleaned_data[
+                    "categorie_juridique_sirene"
+                ],
+                "appartient_groupe": simulation_form.cleaned_data["appartient_groupe"],
+                "effectif": simulation_form.cleaned_data["effectif"],
+                "tranche_chiffre_affaires": simulation_form.cleaned_data[
+                    "tranche_chiffre_affaires"
+                ],
+                "tranche_bilan": simulation_form.cleaned_data["tranche_bilan"],
+                "est_cotee": simulation_form.cleaned_data["est_cotee"],
+                "est_societe_mere": simulation_form.cleaned_data["est_societe_mere"],
+                "comptes_consolides": simulation_form.cleaned_data[
+                    "comptes_consolides"
+                ],
+                "effectif_groupe": simulation_form.cleaned_data["effectif_groupe"],
+                "tranche_chiffre_affaires_consolide": simulation_form.cleaned_data[
+                    "tranche_chiffre_affaires_consolide"
+                ],
+                "tranche_bilan_consolide": simulation_form.cleaned_data[
+                    "tranche_bilan_consolide"
+                ],
+            }
+            return redirect("simulation")
         else:
             messages.error(
                 request,
                 f"Impossible de finaliser la simulation car le formulaire contient des erreurs.",
             )
+    elif request.session.get("simulation"):
+        simulation_form = SimulationForm(request.session["simulation"])
+        reglementations = calcule_simulation(simulation_form, request.user)
+
     return render(
         request,
         "public/simulation.html",


### PR DESCRIPTION
…hargement

Ajout d'une redirection pour éviter qu'un utilisateur fasse une simulation, visite une page 'En savoir plus' puis revienne en arrière sur le formulaire. Dans ce cas, le navigateur force l'utilisateur a recharger la page car la simulation est faite avec un POST. cf. https://stackoverflow.com/questions/19215637/navigate-back-with-php-form-submission